### PR TITLE
Include kubedoc--resource-completion-table-cache in cache invalidation

### DIFF
--- a/kubedoc.el
+++ b/kubedoc.el
@@ -293,7 +293,8 @@ Paths are suffixed with a `/' if they contain any child fields."
 (defun kubedoc-invalidate-cache ()
   "Invalidate kubedoc completion cache."
   (interactive)
-  (setq kubedoc--field-completion-table-cache nil))
+  (setq kubedoc--field-completion-table-cache nil)
+  (setq kubedoc--resource-completion-table-cache nil))
 
 
 ;;;; Mode


### PR DESCRIPTION
I noticed that `kubedoc--resource-completion-table-cache` wasn't in the cache invalidation list