### PR TITLE
Fix issue with resources names that contain a `.`(dot)

### DIFF
--- a/kubedoc.el
+++ b/kubedoc.el
@@ -105,13 +105,19 @@ For example Aggregated APIs with no docs.")
     (let ((field (button-get button 'kubectl-section)))
       (apply #'kubedoc--view-resource (append kubedoc--buffer-path (list field))))))
 
+(defun kubedoc--create-resource-without-api-group (resource)
+  "Takes only the first resource level name from a given resource.
+Example: Takes a `certificaterequests.certmanager.k8s.io` and returns
+`certificaterequests/`."
+  (concat (car (split-string resource "\\.")) "/"))
+
 (defun kubedoc--resource-completion-table ()
   "Completion candidate list for all known Kubernetes resources in the cluster."
   (seq-filter
    (lambda (e)
      (seq-every-p (lambda (regex) (not (string-match-p regex e))) kubedoc-resource-filter))
    (mapcar
-    (lambda (e) (concat e "/"))
+    'kubedoc--create-resource-without-api-group
     (split-string
      (kubedoc--kubectl-command "api-resources" "--output" "name") nil t))))
 


### PR DESCRIPTION
Fix issue with resources like `deployment.apps` or resources with a namespace sufix like `.k8s.io`.

Before:
![image](https://user-images.githubusercontent.com/950087/135937848-10b96e11-1469-452c-b605-0d7d074b04bd.png)

After:
![image](https://user-images.githubusercontent.com/950087/135938479-8c8f5770-4c68-4c36-89bd-4c2bf9812154.png)
